### PR TITLE
feat: spot allocation capacity optimized

### DIFF
--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -192,7 +192,7 @@ func (b *CreateFleetInputBuilder) Build() *ec2.CreateFleetInput {
 	}
 	if b.capacityType == karpv1.CapacityTypeSpot {
 		input.SpotOptions = &ec2types.SpotOptionsRequest{
-			AllocationStrategy: ec2types.SpotAllocationStrategyPriceCapacityOptimized,
+			AllocationStrategy: ec2types.SpotAllocationStrategyCapacityOptimizedPrioritized,
 		}
 	} else if b.capacityReservationType != v1.CapacityReservationTypeCapacityBlock {
 		input.OnDemandOptions = &ec2types.OnDemandOptionsRequest{


### PR DESCRIPTION
Using CapacityOptimiedPrioritized since we have a list of instances in
our nodepool. Aws docs are here [1].

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html#ec2-fleet-allocation-strategies-for-spot-instances
